### PR TITLE
Fleet WS-04: forward engine field through conditioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.5] - 2026-04-13
+
+### Added
+- `:engine` to `send_task` whitelist — conditioner now forwards the engine field from the relationship hash to the downstream SubTask message
+
 ## [0.3.4] - 2026-03-30
 
 ### Added

--- a/lib/legion/extensions/conditioner/runners/conditioner.rb
+++ b/lib/legion/extensions/conditioner/runners/conditioner.rb
@@ -41,7 +41,7 @@ module Legion
 
           def send_task(**opts)
             subtask_hash = {}
-            %i[runner_routing_key relationship_id chain_id trigger_runner_id trigger_function_id function_id function runner_id runner_class transformation debug task_id results].each do |column| # rubocop:disable Layout/LineLength
+            %i[runner_routing_key relationship_id chain_id trigger_runner_id trigger_function_id function_id function runner_id runner_class transformation engine debug task_id results].each do |column| # rubocop:disable Layout/LineLength
               subtask_hash[column] = opts[column] if opts.key? column
             end
 

--- a/lib/legion/extensions/conditioner/version.rb
+++ b/lib/legion/extensions/conditioner/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Conditioner
-      VERSION = '0.3.4'
+      VERSION = '0.3.5'
     end
   end
 end

--- a/spec/legion/extensions/conditioner/runners/conditioner_engine_spec.rb
+++ b/spec/legion/extensions/conditioner/runners/conditioner_engine_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Legion
+  module Extensions
+    module Helpers
+      module Task; end unless defined?(Legion::Extensions::Helpers::Task)
+    end
+  end
+
+  module Transport
+    module Messages
+      unless defined?(Legion::Transport::Messages::SubTask)
+        class SubTask
+          def initialize(**); end
+
+          def publish; end
+        end
+      end
+    end
+  end
+
+  module Exception
+    class MissingArgument < StandardError; end unless defined?(Legion::Exception::MissingArgument)
+  end
+end
+
+require 'legion/extensions/conditioner/runners/conditioner'
+
+RSpec.describe Legion::Extensions::Conditioner::Runners::Conditioner do
+  let(:test_class) do
+    Class.new do
+      include Legion::Extensions::Conditioner::Runners::Conditioner
+    end
+  end
+
+  subject { test_class.new }
+
+  describe '#send_task' do
+    it 'includes engine in the forwarded payload' do
+      message_double = double('SubTask', publish: true)
+      allow(Legion::Transport::Messages::SubTask).to receive(:new).and_return(message_double)
+
+      payload = {
+        runner_routing_key: 'lex.transformer.runners.transform.transform',
+        transformation:     '{"prompt":"summarize"}',
+        engine:             'llm',
+        relationship_id:    1,
+        function_id:        2,
+        function:           'transform',
+        runner_id:          3,
+        runner_class:       'Transform',
+        results:            { data: 'test' }
+      }
+
+      subject.send_task(**payload)
+
+      expect(Legion::Transport::Messages::SubTask).to have_received(:new) do |**args|
+        expect(args[:engine]).to eq('llm')
+      end
+    end
+
+    it 'does not include engine when not present in payload' do
+      message_double = double('SubTask', publish: true)
+      allow(Legion::Transport::Messages::SubTask).to receive(:new).and_return(message_double)
+
+      payload = {
+        runner_routing_key: 'lex.transformer.runners.transform.transform',
+        transformation:     '{"prompt":"summarize"}',
+        relationship_id:    1,
+        function_id:        2,
+        function:           'transform',
+        runner_id:          3,
+        runner_class:       'Transform',
+        results:            { data: 'test' }
+      }
+
+      subject.send_task(**payload)
+
+      expect(Legion::Transport::Messages::SubTask).to have_received(:new) do |**args|
+        expect(args).not_to have_key(:engine)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `:engine` to the `send_task` whitelist in `conditioner.rb`
- The conditioner now forwards the `engine` key from the relationship hash to the downstream SubTask message

## Motivation

The conditioner receives the relationship hash (including `engine`) from lex-tasker's CheckSubtask, then builds a SubTask message via whitelist-filtered kwargs. Without `:engine` in the whitelist, the value was silently dropped.

## Changes

- `lib/legion/extensions/conditioner/runners/conditioner.rb` — adds `:engine` to the `send_task` whitelist between `:transformation` and `:debug`
- `spec/legion/extensions/conditioner/runners/conditioner_engine_spec.rb` (new) — two tests: engine forwarded when present, not forwarded when absent

## Depends On

- LegionIO/legion-data#27
- LegionIO/legion-transport#26
- LegionIO/lex-tasker#N (tasker engine passthrough)

## Merge Order

**Merge fourth** — after legion-data, legion-transport, lex-tasker.

## Test Plan

- [ ] `bundle exec rspec` — 182 examples, 0 failures
- [ ] Part of fleet WS-04